### PR TITLE
meowtube sample - populate video list and use query in search

### DIFF
--- a/samples/meowtube.html
+++ b/samples/meowtube.html
@@ -50,7 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       hidden></iron-ajax>
 
   <div id="flexHorizontal">
-    <dom-repeat items="[[videos.items]]">
+    <dom-repeat data-fake-items-attr="[[videos.items]]">
       <a href="https://www.youtube.com/watch?v=[[item.id.videoId]]">
         <paper-card image="[[item.snippet.thumbnails.high.url]]" style="margin: 10px;width: 200px;">
           <div class="card-content" style="height:50px;overflow:auto;">

--- a/samples/meowtube.html
+++ b/samples/meowtube.html
@@ -50,7 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       hidden></iron-ajax>
 
   <div id="flexHorizontal">
-    <dom-repeat fake-items-attr="[[videos.items]]">
+    <dom-repeat items="[[videos.items]]">
       <a href="https://www.youtube.com/watch?v=[[item.id.videoId]]">
         <paper-card image="[[item.snippet.thumbnails.high.url]]" style="margin: 10px;width: 200px;">
           <div class="card-content" style="height:50px;overflow:auto;">

--- a/samples/meowtube.html
+++ b/samples/meowtube.html
@@ -45,7 +45,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <iron-ajax url="https://www.googleapis.com/youtube/v3/search"
       handle-as="json" auto="true"
-      params='{"part":"snippet", "q":"cats", "key": "AIzaSyAuecFZ9xJXbGDkQYWBmYrtzOGJD-iDIgI", "type": "video", "maxResults":"10"}'
+      params='{"part":"snippet", "q":"[[query]] cats", "key": "AIzaSyAuecFZ9xJXbGDkQYWBmYrtzOGJD-iDIgI", "type": "video", "maxResults":"10"}'
       last-response="{{videos}}"
       hidden></iron-ajax>
 


### PR DESCRIPTION
I enjoyed watching @notwaldorf's talk and demo of wizzywid on YouTube - thank you!

I noticed when loading the meowtube sample that it didn't behave as I expected from the demo;

1. The videos were not displaying
2. The iron-ajax query was not using the paper-input query value

This PR does two things;

1.  Changes the `fake-items-attr` attribute to `data-fake-items-attr` on `dom-repeat`
2. Includes `[[query]]` in the `params` attribute of `iron-ajax`